### PR TITLE
Add YAML-based application configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,5 @@ app.*.map.json
 
 # --- secrets & 민감정보 ---
 /lib/config/*
-lib/config/config.dart
+!lib/config/config.dart
 

--- a/README.md
+++ b/README.md
@@ -284,3 +284,23 @@ class AppState {
 * [ ] 로그 뷰어: 초기 30줄, 상/하단 이동, 검색 동작
 * [ ] 체결/오류 푸시 중복 차단 정상 동작
 * [ ] `targetCoin` 비어있을 때 시작 차단 + 저장/복원 확인
+
+---
+
+# ⚙️ Configuration
+
+`lib/config/config.dart` provides an `AppConfig` helper that reads values from a `config.yaml` file or environment variables. Create a `config.yaml` in the project root or define the `API_KEY`, `API_SECRET`, and `BASE_URL` environment variables:
+
+```yaml
+apiKey: YOUR_API_KEY
+apiSecret: YOUR_API_SECRET
+baseUrl: https://api.yourservice.com
+```
+
+Environment variables take precedence over the YAML file. Access the values in code via:
+
+```dart
+final config = AppConfig();
+print(config.apiKey);
+```
+

--- a/lib/config/config.dart
+++ b/lib/config/config.dart
@@ -1,0 +1,40 @@
+// filepath: lib/config/config.dart
+
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+/// AppConfig loads configuration from a `config.yaml` file or
+/// environment variables.
+///
+/// Environment variables take precedence over the YAML file.
+class AppConfig {
+  AppConfig._internal();
+
+  static final AppConfig _instance = AppConfig._internal();
+
+  /// Returns the singleton instance of [AppConfig].
+  factory AppConfig() => _instance;
+
+  late final Map<String, dynamic> _yaml = _loadYaml();
+
+  Map<String, dynamic> _loadYaml() {
+    final file = File('config.yaml');
+    if (file.existsSync()) {
+      final yamlMap = loadYaml(file.readAsStringSync()) as YamlMap;
+      return Map<String, dynamic>.from(yamlMap);
+    }
+    return {};
+  }
+
+  String get apiKey => _getString('API_KEY', 'apiKey');
+
+  String get apiSecret => _getString('API_SECRET', 'apiSecret');
+
+  String get baseUrl => _getString('BASE_URL', 'baseUrl');
+
+  String _getString(String envKey, String yamlKey) {
+    return Platform.environment[envKey] ?? _yaml[yamlKey] ?? '';
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   permission_handler: ^12.0.1
   shared_preferences: ^2.5.3
   flutter_launcher_icons: ^0.14.4
+  yaml: ^3.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- provide `AppConfig` singleton to read API credentials from `config.yaml` or environment variables
- document configuration usage and add `yaml` dependency

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d0bdcd94832ca592acd7af6fb598