### PR TITLE
feat: add Coinone private API wrapper

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 import '../services/coinone_api.dart';
+import '../services/coinone_private.dart';
 import '../services/auto_trade_service.dart';
 import '../widgets/log_console_box.dart';
 import 'dart:async';
@@ -106,7 +107,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
       _canStart = true;
 
       final price = await CoinoneAPI.getCurrentPrice(coin);
-      final balances = await CoinoneAPI.getBalanceMap();
+      final balances = await CoinonePrivate.getBalanceMap();
 
       final qty =
           double.tryParse(balances?[coin.toLowerCase()]?['avail'] ?? '0') ?? 0;

--- a/lib/services/auto_trade_service.dart
+++ b/lib/services/auto_trade_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import '../services/coinone_api.dart';
+import '../services/coinone_private.dart';
 import '../strategy/rebound_detector.dart';
 import '../strategy/trend_guard.dart';
 import '../strategy/trade_executor.dart';
@@ -89,7 +90,7 @@ class AutoTradeService {
       if (price == null) return;
       latestPrice = price;
 
-      final balances = await CoinoneAPI.getBalanceMap();
+      final balances = await CoinonePrivate.getBalanceMap();
       final coinData = balances?[_targetCoin!.toLowerCase()];
       final qty = double.tryParse(coinData?["avail"] ?? "0") ?? 0;
       final avg = double.tryParse(coinData?["avg"] ?? "0") ?? 0;

--- a/lib/services/coinone_api.dart
+++ b/lib/services/coinone_api.dart
@@ -1,11 +1,7 @@
 import 'dart:convert';
-import 'package:crypto/crypto.dart';
-import 'package:convert/convert.dart';
 import 'package:http/http.dart' as http;
 import '../config/config.dart';
 import '../utils/log.dart';
-import 'package:uuid/uuid.dart';
-
 
 class CoinoneAPI {
   static Future<double?> getCurrentPrice(String coin) async {
@@ -36,69 +32,6 @@ class CoinoneAPI {
       log.e("❌ 현재가 API 오류 ($coin): $e");
       return null;
     }
-  }
-
-  static Future<List?> getBalances() async {
-    final url = Uri.parse('${AppConfig.baseUrl}/v2.1/account/balance/all');
-    final nonce = const Uuid().v4();  // ✅ UUID v4 형식
-
-    final payload = {
-      "access_token": AppConfig.apiKey,
-      "nonce": nonce,
-    };
-
-    final jsonStr = jsonEncode(payload);
-    final base64Payload = base64.encode(utf8.encode(jsonStr));
-
-    final hmac = Hmac(sha512, utf8.encode(AppConfig.apiSecret));
-    final signature = hex.encode(
-      hmac.convert(utf8.encode(base64Payload)).bytes,
-    );
-
-    final headers = {
-      'Content-Type': 'application/json',
-      'X-COINONE-PAYLOAD': base64Payload,
-      'X-COINONE-SIGNATURE': signature,
-    };
-
-    try {
-      log.d("📡 [잔고 요청] $url");
-
-      final response = await http.post(url, headers: headers, body: jsonStr);
-
-      log.d("📥 [응답 상태] ${response.statusCode}");
-      log.d("📦 [응답 본문] ${response.body}");
-
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        log.i("💰 잔고 조회 성공");
-        return data['balances'] as List<dynamic>?; // ✅ 리스트로 반환
-      } else {
-        log.w("⚠️ 잔고 조회 실패: ${response.statusCode}");
-        return null;
-      }
-    } catch (e) {
-      log.e("❌ 잔고 조회 오류: $e");
-    }
-    return null;
-  }
-
-  static Future<Map<String, Map<String, String>>> getBalanceMap() async {
-    final raw = await getBalances(); // 기존 리스트 반환 함수
-    if (raw == null) return {};
-
-    final Map<String, Map<String, String>> result = {};
-    for (final item in raw) {
-      final currency = item['currency']?.toString().toLowerCase();
-      if (currency != null) {
-        result[currency] = {
-          'avail': item['available'] ?? '0',
-          'limit': item['limit'] ?? '0',
-          'avg': item['average_price'] ?? '0',
-        };
-      }
-    }
-    return result;
   }
 
   static Future<List<Map<String, dynamic>>?> getCandles(
@@ -143,54 +76,4 @@ class CoinoneAPI {
     return null;
   }
 
-  static Future<bool> placeOrder({
-    required String symbol,
-    required String side,
-    required double qty,
-  }) async {
-    final endpoint = side == 'buy'
-        ? '/v2/order/market_buy/'
-        : '/v2/order/market_sell/';
-    final url = Uri.parse('${AppConfig.baseUrl}$endpoint');
-
-    final payload = {
-      "access_token": AppConfig.apiKey,
-      "nonce": DateTime.now().millisecondsSinceEpoch.toString(),
-      "qty": qty.toString(),
-      "currency": symbol.toLowerCase(),
-    };
-
-    final jsonStr = jsonEncode(payload);
-    final base64Payload = base64.encode(utf8.encode(jsonStr));
-
-    final hmac = Hmac(sha512, utf8.encode(AppConfig.apiSecret));
-    final signature = hex.encode(
-      hmac.convert(utf8.encode(base64Payload)).bytes,
-    );
-
-    final headers = {
-      'Content-Type': 'application/json',
-      'X-COINONE-PAYLOAD': base64Payload,
-      'X-COINONE-SIGNATURE': signature,
-    };
-
-    try {
-      final response = await http.post(url, headers: headers, body: jsonStr);
-
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        if (data["result"] == "success") {
-          log.i("✅ $side 주문 성공: $qty $symbol");
-          return true;
-        } else {
-          log.w("⚠️ 주문 실패: ${data['errorMsg']}");
-        }
-      } else {
-        log.e("❌ HTTP 오류: ${response.statusCode}");
-      }
-    } catch (e) {
-      log.e("❗ 예외 발생: $e");
-    }
-    return false;
-  }
 }

--- a/lib/services/coinone_private.dart
+++ b/lib/services/coinone_private.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:uuid/uuid.dart';
+
+import '../config/config.dart';
+import '../utils/log.dart';
+
+/// Wrapper for Coinone's private REST endpoints (v2.1).
+///
+/// Provides helpers to create signed requests and expose
+/// convenient methods for common account and order actions.
+class CoinonePrivate {
+  // ----------------------
+  // Endpoint definitions
+  // ----------------------
+  static const _base = '/v2.1';
+  static const _marketOrder = '$_base/order/market';
+  static const _limitOrder = '$_base/order/limit';
+  static const _cancelOrder = '$_base/order/cancel';
+  static const _orderInfo = '$_base/order/status';
+  static const _balanceAll = '$_base/account/balance/all';
+
+  // ----------------------
+  // Signature helpers
+  // ----------------------
+  static String _nonce() => const Uuid().v4();
+
+  static Map<String, dynamic> _authBody(Map<String, dynamic> body) => {
+        'access_token': AppConfig.apiKey,
+        'nonce': _nonce(),
+        ...body,
+      };
+
+  static Map<String, String> _headers(String jsonStr) {
+    final base64Payload = base64.encode(utf8.encode(jsonStr));
+    final hmac = Hmac(sha512, utf8.encode(AppConfig.apiSecret));
+    final signature =
+        hex.encode(hmac.convert(utf8.encode(base64Payload)).bytes);
+    return {
+      'Content-Type': 'application/json',
+      'X-COINONE-PAYLOAD': base64Payload,
+      'X-COINONE-SIGNATURE': signature,
+    };
+  }
+
+  static Future<Map<String, dynamic>?> _post(
+      String endpoint, Map<String, dynamic> body) async {
+    final payload = _authBody(body);
+    final jsonStr = jsonEncode(payload);
+    final headers = _headers(jsonStr);
+    final url = Uri.parse('${AppConfig.baseUrl}$endpoint');
+
+    try {
+      log.d("📡 [POST] $url");
+      final res = await http.post(url, headers: headers, body: jsonStr);
+      log.d("📥 [응답 상태] ${res.statusCode}");
+      log.d("📦 [응답 본문] ${res.body}");
+
+      if (res.statusCode == 200) {
+        return jsonDecode(res.body) as Map<String, dynamic>;
+      }
+    } catch (e) {
+      log.e("❌ API 요청 오류: $e");
+    }
+    return null;
+  }
+
+  // ----------------------
+  // API methods
+  // ----------------------
+
+  /// Create a market order.
+  static Future<Map<String, dynamic>?> createMarketOrder({
+    required String symbol,
+    required String side,
+    required double qty,
+  }) async {
+    return _post(_marketOrder, {
+      'symbol': symbol.toLowerCase(),
+      'side': side,
+      'qty': qty.toString(),
+    });
+  }
+
+  /// Create a limit order.
+  static Future<Map<String, dynamic>?> createLimitOrder({
+    required String symbol,
+    required String side,
+    required double qty,
+    required double price,
+  }) async {
+    return _post(_limitOrder, {
+      'symbol': symbol.toLowerCase(),
+      'side': side,
+      'qty': qty.toString(),
+      'price': price.toString(),
+    });
+  }
+
+  /// Cancel an order by [orderId].
+  static Future<Map<String, dynamic>?> cancelOrder({
+    required String orderId,
+    required String symbol,
+  }) async {
+    return _post(_cancelOrder, {
+      'order_id': orderId,
+      'symbol': symbol.toLowerCase(),
+    });
+  }
+
+  /// Retrieve details for a specific order.
+  static Future<Map<String, dynamic>?> getOrder({
+    required String orderId,
+    required String symbol,
+  }) async {
+    return _post(_orderInfo, {
+      'order_id': orderId,
+      'symbol': symbol.toLowerCase(),
+    });
+  }
+
+  /// Fetch raw balance list.
+  static Future<List?> getBalances() async {
+    final res = await _post(_balanceAll, {});
+    return res?['balances'] as List?;
+  }
+
+  /// Convenience map of balances keyed by currency.
+  static Future<Map<String, Map<String, String>>> getBalanceMap() async {
+    final raw = await getBalances();
+    if (raw == null) return {};
+
+    final Map<String, Map<String, String>> result = {};
+    for (final item in raw) {
+      final currency = item['currency']?.toString().toLowerCase();
+      if (currency != null) {
+        result[currency] = {
+          'avail': item['available'] ?? '0',
+          'limit': item['limit'] ?? '0',
+          'avg': item['average_price'] ?? '0',
+        };
+      }
+    }
+    return result;
+  }
+}
+

--- a/lib/strategy/trade_executor.dart
+++ b/lib/strategy/trade_executor.dart
@@ -1,4 +1,4 @@
-import '../services/coinone_api.dart';
+import '../services/coinone_private.dart';
 import '../utils/log.dart';
 
 class TradeExecutor {
@@ -17,11 +17,13 @@ class TradeExecutor {
     if (qty <= 0) return false;
 
     log.i("🔻 매도 조건 충족 → 전량 매도 시도");
-    final success = await CoinoneAPI.placeOrder(
-      symbol: _targetCoin ?? "",
-      side: "sell",
+    final result = await CoinonePrivate.createMarketOrder(
+      symbol: _targetCoin ?? '',
+      side: 'sell',
       qty: qty,
     );
+
+    final success = result != null && result['result'] == 'success';
 
     if (success) {
       log.i("✅ 전량 매도 완료: $qty $_targetCoin");
@@ -44,11 +46,13 @@ class TradeExecutor {
     final qty = krwBalance / price;
 
     log.i("🟢 매수 조건 충족 → 전액 매수 시도");
-    final success = await CoinoneAPI.placeOrder(
-      symbol: _targetCoin ?? "",
-      side: "buy",
+    final result = await CoinonePrivate.createMarketOrder(
+      symbol: _targetCoin ?? '',
+      side: 'buy',
       qty: qty,
     );
+
+    final success = result != null && result['result'] == 'success';
 
     if (success) {
       log.i("✅ 매수 성공: $qty $_targetCoin");


### PR DESCRIPTION
## Summary
- add CoinonePrivate service with v2.1 endpoints and auth helpers
- replace order and balance calls to use CoinonePrivate
- prune legacy private methods from CoinoneAPI

## Testing
- `dart format lib/services/coinone_api.dart lib/services/coinone_private.dart lib/strategy/trade_executor.dart lib/services/auto_trade_service.dart lib/screens/dashboard_screen.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e1d1c774832c9823cd9be4680710