### PR TITLE
Add top-k ticker loop with candle caching and rate limiter

### DIFF
--- a/lib/services/coinone_api.dart
+++ b/lib/services/coinone_api.dart
@@ -5,9 +5,32 @@ import 'package:http/http.dart' as http;
 import '../config/config.dart';
 import '../utils/log.dart';
 import 'package:uuid/uuid.dart';
+import '../utils/rate_limiter.dart';
 
 
 class CoinoneAPI {
+  // Simple in-memory cache for candle data
+  static final Map<String, _CandleCache> _candleCache = {};
+
+  static Future<Map<String, dynamic>?> getAllTickers() async {
+    final url = Uri.parse("https://api.coinone.co.kr/ticker?currency=all");
+    try {
+      final response = await RateLimiter.run(() => http.get(url));
+      if (response.statusCode != 200) return null;
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+
+      final result = <String, Map<String, dynamic>>{};
+      data.forEach((key, value) {
+        if (value is Map<String, dynamic> && value.containsKey('volume')) {
+          result[key] = value;
+        }
+      });
+      return result;
+    } catch (e) {
+      log.e("❌ 전체 티커 조회 오류: $e");
+      return null;
+    }
+  }
   static Future<double?> getCurrentPrice(String coin) async {
     final url = Uri.parse("https://api.coinone.co.kr/ticker?currency=$coin");
 
@@ -106,15 +129,21 @@ class CoinoneAPI {
     required String interval,
     int limit = 10,
   }) async {
+    final cacheKey = '$symbol:$interval:$limit';
+    final now = DateTime.now();
+    final cached = _candleCache[cacheKey];
+    if (cached != null && now.difference(cached.fetchedAt).inSeconds < 60) {
+      return cached.data;
+    }
+
     final url = Uri.parse(
       '${AppConfig.baseUrl}/public/v2/chart/KRW/$symbol?interval=$interval&size=$limit',
     );
 
     try {
-
       log.d("📡 [캔들 요청] $url");
 
-      final response = await http.get(url);
+      final response = await RateLimiter.run(() => http.get(url));
 
       log.d("📥 [응답 상태] ${response.statusCode}");
       log.d("📦 [응답 본문] ${response.body}");
@@ -127,7 +156,9 @@ class CoinoneAPI {
         if (data is Map<String, dynamic> && data.containsKey('chart')) {
           final chart = data['chart'];
           if (chart is List) {
-            return List<Map<String, dynamic>>.from(chart);
+            final list = List<Map<String, dynamic>>.from(chart);
+            _candleCache[cacheKey] = _CandleCache(now, list);
+            return list;
           } else {
             log.w("❗ 'chart' 필드는 리스트가 아님");
           }
@@ -193,4 +224,10 @@ class CoinoneAPI {
     }
     return false;
   }
+}
+
+class _CandleCache {
+  final DateTime fetchedAt;
+  final List<Map<String, dynamic>> data;
+  _CandleCache(this.fetchedAt, this.data);
 }

--- a/lib/utils/rate_limiter.dart
+++ b/lib/utils/rate_limiter.dart
@@ -1,0 +1,23 @@
+import 'dart:async';
+
+class RateLimiter {
+  const RateLimiter._();
+
+  /// Runs [action] with simple exponential backoff.
+  /// Retries up to [maxAttempts] times when an exception is thrown.
+  static Future<T> run<T>(Future<T> Function() action,
+      {int maxAttempts = 3, Duration initialDelay = const Duration(milliseconds: 500)}) async {
+    var attempt = 0;
+    var delay = initialDelay;
+    while (true) {
+      try {
+        return await action();
+      } catch (e) {
+        attempt++;
+        if (attempt >= maxAttempts) rethrow;
+        await Future.delayed(delay);
+        delay *= 2;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Switch auto-trading loop to run every minute, picking top-volume tickers before evaluating
- Cache recent candle data and wrap API requests with a backoff rate limiter
- Introduce reusable `RateLimiter` utility

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f7ac39fc832c9428056323719385